### PR TITLE
Feature request: Signup form from the post layout

### DIFF
--- a/_data/locales/post.yml
+++ b/_data/locales/post.yml
@@ -22,6 +22,45 @@ twitterhandle:
 slack:
   en: Slack
   fr: Slack&nbsp;
+signup:
+  en: Sign up to the Digital Transformation Office mailing list
+  fr: Abonnez-vous à la liste d’envoi du Bureau de la transformation numérique
+intro:
+  en: Sign up to our mailing list to find out about workshops, events, user research and usability testing activities that you may want to participate in.
+  fr: Abonnez-vous à notre liste d’envoi pour des renseignements au sujet des ateliers, des événements, des activités de recherche sur les utilisateurs et des tests de convivialité auxquels vous pourriez vouloir participer.
+mce-email:
+  en: Email address
+  fr: Votre courriel
+emailtype:
+  en: Preferred newsletter format
+  fr: Format d'infolettre désirée
+emailtype1:
+  en: HTML
+  fr: HTML
+emailtype2:
+  en: plain text
+  fr: texte clair
+emailtype-cmmt:
+  en: (We recommend 'plain text' if your firewall might block HTML emails)
+  fr: (Nous recommandons 'texte clair' si votre pare-feu bloque les courriels HTML)
+subscribe:
+  en: Subscribe
+  fr: Abonnez-vous
+privacy-notice:
+  en: Privacy notice
+  fr: Énoncé de confidentialité
+privacy-notice1:
+  en: Our newsletter feature uses <a href="https://mailchimp.com/">Mailchimp</a>, a third-party application. Sign-up is voluntary and subject to the <a href="https://mailchimp.com/legal/terms/">Terms of Use</a> for the Mailchimp platform.  When you sign up, your email address and language preference (English or French) is collected. No other personal information is collected.
+  fr: Notre fonction Bulletin de nouvelles fait appel &agrave; <a href="https://mailchimp.com/">Mailchimp</a>, une application tierce. L'adh&eacute;sion est libre et est assujettie aux <a href="https://mailchimp.com/legal/terms/">Conditions d'utilisation</a> associ&eacute;es &agrave; la plateforme Mailchimp. Au moment de l'adh&eacute;sion, le syst&egrave;me enregistre votre adresse &eacute;lectronique et votre langue de pr&eacute;f&eacute;rence (anglais ou fran&ccedil;ais). Aucun autre renseignement personnel n'est recueilli.
+privacy-notice2:
+  en: The collection and use of your personal information is authorized by the <em>Financial Administration Act</em>. Collection and use of your personal information for this site is in accordance with the federal <em>Privacy Act</em>. Your personal information may be used to respond to your inquiries, if applicable, and to help evaluate the effectiveness of Treasury Board of Canada Secretariat (TBS) programs in responding to client needs. In exceptional circumstances (e.g., individuals who make inappropriate remarks or threats), personal information may be disclosed without your consent pursuant to subsection 8(2) of the <em>Privacy Act</em>.
+  fr: La collecte et l'utilisation de vos renseignements personnels sont autoris&eacute;es par la <em>Loi sur la gestion des finances publiques</em>. La collecte et l'utilisation de vos renseignements personnels aux fins du pr&eacute;sent site sont conformes &agrave; la <em>Loi f&eacute;d&eacute;rale sur la protection des renseignements personnels</em>. Vos renseignements personnels peuvent servir &agrave; r&eacute;pondre &agrave; vos demandes de renseignements, au besoin, et &agrave; &eacute;valuer l'efficacit&eacute; avec laquelle les programmes du Secr&eacute;tariat du Conseil du Tr&eacute;sor (SCT) r&eacute;pondent aux besoins des clients. Dans des cas exceptionnels (p. ex., le cas de quelqu'un qui fait des remarques inappropri&eacute;es ou des menaces), les renseignements personnels peuvent &ecirc;tre divulgu&eacute;s sans votre consentement conform&eacute;ment au paragraphe 8(2) de la <em>Loi sur la protection des renseignements personnels</em>.
+privacy-notice3:
+  en: Any personal information that may be collected is described in the Standard Personal Information Bank entitled <a href="http://www.infosource.gc.ca/emp/emp03-eng.asp#psu938">Outreach Activities, PSU 938</a>, which can be found in the TBS webpage <a href="https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings.html">Information about programs and information holdings</a>.
+  fr: Tout renseignement personnel qui pourra &ecirc;tre recueilli est d&eacute;crit dans le Fichier de renseignement personnel ordinaire intitul&eacute; <a href="http://www.infosource.gc.ca/emp/emp03-fra.asp#psu938">Activit&eacute;s de sensibilisation, POU 938</a> qui figure sur la page Web du SCT intitul&eacute;e <a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html"><em>Renseignements sur les programmes et les fonds de renseignements</em></a>.
+privacy-notice4:
+  en: Any questions, comments, concerns or complaints you may have regarding this Statement, your privacy rights and the Privacy Act may be directed to the TBS Access to Information and Privacy Coordinator by email at <a href="mailto:ATIP.AIPRP@TBS-SCT.gc.ca">ATIP.AIPRP@tbs-sct.gc.ca</a> or by telephone at 1-866-312-1511. You may also wish to contact the Office of the Privacy Commissioner of Canada by email at <a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a> or by telephone at 1-800-282-1376. You have the right to complain to the Office of the Privacy Commissioner of Canada about the handling of your personal information by TBS.
+  fr: Pour transmettre vos questions, commentaires ou pr&eacute;occupations concernant le pr&eacute;sent avis, vos droits en mati&egrave;re de protection des renseignements personnels ou la <em>Loi sur la protection des renseignements personnels</em>, communiquez avec le coordonnateur de l&rsquo;acc&egrave;s &agrave; l&rsquo;information et de la protection des renseignements personnels du SCT, &agrave; <a href="mailto:atip.aiprp@tbs-sct.gc.ca">atip.aiprp@tbs-sct.gc.ca</a>, ou en composant le 1-866-312-1511. Vous pouvez aussi communiquer avec le Commissariat &agrave; la protection de la vie priv&eacute;e du Canada par courriel, &agrave; <a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a>, ou par t&eacute;l&eacute;phone, au 1-800-282-1376. Vous avez &eacute;galement la possibilit&eacute; de d&eacute;poser une plainte aupr&egrave;s du Commissariat &agrave; la protection de la vie priv&eacute;e du Canada quant &agrave; la fa&ccedil;on dont le SCT traite vos renseignements personnels.
 next:
   en: Next blog post
   fr: Billet suivant

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,17 +4,93 @@ layout: default
 
 {%- assign locales = site.data.locales.post -%}
 <div class="blogholder img-responsive">
-  <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
-	<div class="post-content" itemprop="articleBody">
-		{{ content }}
+	<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+		<div class="post-content" itemprop="articleBody">
+			{{ content }}
+		</div>
+	</article>
+	<aside>
 		<h2 id="{{ locales.connect[ page.lang ] | downcase | replace: ' ', '-' }}">{{ locales.connect[ page.lang ] }}</h2>
 		<ul>
 			<li>{{ locales.email[ page.lang ] }}: <a href="mailto:dto.btn@tbs-sct.gc.ca">dto.btn@tbs-sct.gc.ca</a></li>
 			<li>{{ locales.twitter[ page.lang ] }}: {{ locales.twitterhandle[ page.lang ] }}</li>
 			<li>{{ locales.slack[ page.lang ] }}: <a href="https://design-gc-conception.slack.com/join/shared_invite/enQtODE1OTc5Mzg5NzQ4LWQ3MjZjMTdjMjk2ZTZmMTJjYWQ3ZmRiNDYwYjRmN2NjYzQyNjFlNDBlY2FkNWE1ODg2YjExY2QwZmVjN2MwMGM">http://design-GC-conception.slack.com</a></li>
+			<li>{{ locales.signup[ page.lang ] }}:
+				<ul class="list-unstyled">
+					<li>
+						<form action="https://github.us12.list-manage.com/subscribe/post?u=5700d338d6ab413ebca1099f4&amp;id=c6bb0b9f64" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate paddingc" target="_blank" novalidate>
+							<div id="mc_embed_signup_scroll" class="well well-sm">
+								<fieldset class="gc-chckbxrdio">
+									<legend>{{ locales.emailtype[ page.lang ] }}</legend>
+									<ul class="list-unstyled lst-spcd-2">
+										<li class="radio">
+											<input type="radio" value="html" name="EMAILTYPE" id="mce-EMAILTYPE-0">
+											<label for="mce-EMAILTYPE-0">{{ locales.emailtype1[ page.lang ] }}</label>
+										</li>
+										<li class="radio">
+											<input type="radio" value="text" name="EMAILTYPE" id="mce-EMAILTYPE-1">
+											<label for="mce-EMAILTYPE-1">{{ locales.emailtype2[ page.lang ] }} <small>{{ locales.emailtype-cmmt[ page.lang ] }}</small></label>
+										</li>
+									</ul>
+								</fieldset>
+								<div class="mc-field-group">
+									<div class="input-group">
+										<label class="wb-inv" for="mce-EMAIL">{{ locales.mce-email[ page.lang ] }}</label>
+										<input type="email" value="" name="EMAIL" class="form-control required email" id="mce-EMAIL" placeholder="{{ locales.mce-email[ page.lang ] }}">
+										<span class="input-group-btn">
+											<button type="submit" name="subscribe" id="mc-embedded-subscribe" class="btn btn-success nowrap">{{ locales.subscribe[ page.lang ] }}</button>
+										</span>
+									</div>
+								</div>
+								<div id="mce-responses" class="clear">
+									<div class="response" id="mce-error-response" style="display:none"></div>
+									<div class="response" id="mce-success-response" style="display:none"></div>
+								</div><!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+								<div style="position: absolute; left: -5000px;" aria-hidden="true">
+									<input type="text" name="b_5700d338d6ab413ebca1099f4_c6bb0b9f64" tabindex="-1" value="">
+								</div>
+							</div>
+						</form>
+					</li>
+				</ul>
+			</li>
 		</ul>
-	</div>
-  </article>
+		<script type='text/javascript' src='https://s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
+		<script type='text/javascript'>
+			( function( $ ) {
+				window.fnames = new Array();
+				window.ftypes = new Array();
+				fnames[ 0 ]='EMAIL';
+				ftypes[ 0 ]='email';
+				fnames[ 1 ]='FNAME';
+				ftypes[ 1 ]='text';
+				fnames[ 2 ]='LNAME';
+				ftypes[ 2 ]='text';
+				fnames[ 3 ]='ADDRESS';
+				ftypes[ 3 ]='address';
+				fnames[ 4 ]='PHONE';
+				ftypes[ 4 ]='phone';
+				fnames[ 5 ]='BIRTHDAY';
+				ftypes[ 5 ]='birthday';
+			}( jQuery ));
+			var $mcj = jQuery.noConflict( true );
+		</script>
+		<!--End mc_embed_signup-->
+		<div class="mce-privacy" style="padding-top: 9px;">
+			<a href="#privacy-notice-modal" aria-controls="privacy-notice-modal" class="overlay-lnk light-link wb-lbx" aria-label="Privacy Statement Link">{{ locales.privacy-notice[ page.lang ] }}</a>
+		</div>
+		<section class="mfp-hide modal-dialog modal-content overlay-def" id="privacy-notice-modal">
+			<header class="modal-header">
+				<h2 class="modal-title">{{ locales.privacy-notice[ page.lang ] }}</h2>
+			</header>
+			<div class="modal-body">
+				<p>{{ locales.privacy-notice1[ page.lang ] }}</p>
+				<p>{{ locales.privacy-notice2[ page.lang ] }}</p>
+				<p>{{ locales.privacy-notice3[ page.lang ] }}</p>
+				<p>{{ locales.privacy-notice4[ page.lang ] }}</p>
+			</div>
+		</section>
+	</aside>
 </div>
 <nav class="mrgn-tp-xl">
 	<h2 class="wb-inv">{{ locales.navigation[ page.lang ] }}</h2>


### PR DESCRIPTION
---
name: Signup form
about: This a gerneral pull request to add a signup form to the newsletter in the post layout
title: 'Feature request: Signup form from the post layout'
labels: 'enhancement'
assignees: '@delisma'
---

### What does this MR do?

This PR addresses the feature request in issue #34. The main solution would be an email input field directly at the bottom of the blog post.

![image](https://user-images.githubusercontent.com/2599251/121405607-3d0d7180-c92b-11eb-9763-378a7f138905.png)

### General checklist

- [x] [Documentation](README.md) created/updated
- [x] Changelog entry added, if necessary
- [ ] Tests added for this feature/bug
- [x] Conforms to the [style guides](https://www.canada.ca/en/government/about/design-system.html)

### Related issues
#34