### PR TITLE
fix: Update action url in `searchsite.html` and pages

### DIFF
--- a/_includes/headers-includes/sitesearch.html
+++ b/_includes/headers-includes/sitesearch.html
@@ -1,0 +1,17 @@
+
+<section id="wb-srch" class="col-lg-offset-4 col-md-offset-4 col-sm-offset-2 col-xs-12 col-sm-5 col-md-4">
+	<h2>{{ i18nText-search }}</h2>
+	<form action="https://canada.ca/{{ i18nText-lang }}/sr/srb.html" method="get" name="cse-search-box" role="search">
+		<div class="form-group wb-srch-qry">
+			<label for="wb-srch-q" class="wb-inv">{{ i18nText-searchSite }}</label>
+			<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="{{ i18nText-searchSite }}" />
+			<datalist id="wb-srch-q-ac"></datalist>
+		</div>
+		<div class="form-group submit">
+			<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
+				<span class="glyphicon-search glyphicon"></span>
+				<span class="wb-inv">{{ i18nText-search }}</span>
+			</button>
+		</div>
+	</form>
+</section>

--- a/en/pages/Canada.ca-spring-update.html
+++ b/en/pages/Canada.ca-spring-update.html
@@ -70,7 +70,7 @@
 				</div>
 				<section id="wb-srch" class="col-lg-8 text-right">
 					<h2>Search</h2>
-					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+					<form action="https://canada.ca/en/sr/srb.html" method="get" role="search" class="form-inline">
 
 						<div class="form-group">
 

--- a/en/pages/_drafts/project-overview-draft.html
+++ b/en/pages/_drafts/project-overview-draft.html
@@ -38,7 +38,7 @@
 				</div>
 				<section id="wb-srch" class="col-lg-8 text-right">
 					<h2>Search</h2>
-					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+					<form action="https://canada.ca/en/sr/srb.html" method="get" role="search" class="form-inline">
 						<div class="form-group">
 							<label for="wb-srch-q" class="wb-inv">Search website</label>
 							<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">

--- a/en/pages/_drafts/project-overview-draft3.html
+++ b/en/pages/_drafts/project-overview-draft3.html
@@ -53,7 +53,7 @@
 </div>
 <section id="wb-srch" class="col-lg-8 text-right">
 <h2>Search</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+<form action="https://canada.ca/en/sr/srb.html" method="get" role="search" class="form-inline">
 
 <div class="form-group">
 

--- a/en/pages/project-overview.html
+++ b/en/pages/project-overview.html
@@ -59,7 +59,7 @@
 				</div>
 				<section id="wb-srch" class="col-lg-8 text-right">
 					<h2>Search</h2>
-					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+					<form action="https://canada.ca/en/sr/srb.html" method="get" role="search" class="form-inline">
 
 						<div class="form-group">
 

--- a/en/pages/starting-a-business-decisions.html
+++ b/en/pages/starting-a-business-decisions.html
@@ -41,7 +41,7 @@
 				</div>
 				<section id="wb-srch" class="col-lg-8 text-right">
 					<h2>Search</h2>
-					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+					<form action="https://canada.ca/en/sr/srb.html" method="get" role="search" class="form-inline">
 						<div class="form-group">
 							<label for="wb-srch-q" class="wb-inv">Search website</label>
 							<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">

--- a/fr/pages/_drafts/apercu-projet-draft-plzrestart-need-toggles-from-latest-live.html
+++ b/fr/pages/_drafts/apercu-projet-draft-plzrestart-need-toggles-from-latest-live.html
@@ -50,7 +50,7 @@
 					<section id="wb-srch" class="col-lg-8 text-right">
 
 						<h2>Recherche</h2>
-						<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+						<form action="https://canada.ca/fr/sr/srb.html" method="get" role="search" class="form-inline">
 							<div class="form-group">
 								<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
 								<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">

--- a/fr/pages/_drafts/apercu-projet-draft.html
+++ b/fr/pages/_drafts/apercu-projet-draft.html
@@ -50,7 +50,7 @@
 					<section id="wb-srch" class="col-lg-8 text-right">
 
 						<h2>Recherche</h2>
-						<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+						<form action="https://canada.ca/fr/sr/srb.html" method="get" role="search" class="form-inline">
 							<div class="form-group">
 								<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
 								<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">

--- a/fr/pages/apercu-projet.html
+++ b/fr/pages/apercu-projet.html
@@ -50,7 +50,7 @@
 					<section id="wb-srch" class="col-lg-8 text-right">
 
 						<h2>Recherche</h2>
-						<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+						<form action="https://canada.ca/fr/sr/srb.html" method="get" role="search" class="form-inline">
 							<div class="form-group">
 								<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
 								<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">

--- a/fr/pages/decisions-demarrer-entreprise.html
+++ b/fr/pages/decisions-demarrer-entreprise.html
@@ -54,7 +54,7 @@
 </div>
 <section id="wb-srch" class="col-lg-8 text-right">
 	<h2>Recherche</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+<form action="https://canada.ca/fr/sr/srb.html" method="get" role="search" class="form-inline">
 
 <div class="form-group">
 


### PR DESCRIPTION
---
name: Global search
about: This a pull request to fix enable the global search in the header
title: 'fix: Update action url in `searchsite.html` and pages'
labels: 'bug'
assignees: '@delisma'
---

### What does this MR do?
The action url in the global search is set to `#` in the posts and to `https://recherche-search.gc.ca` on summary pages.In order for the search to work properly it needs to be set up to 'https://canada.ca/[lang]/sr/serb.html

### Preview links
en: [Blog](https://deploy-preview-71--blog-tbs.netlify.app)
fr: [Blogue](https://deploy-preview-71--blogue-sct.netlify.app)