### PR TITLE
Remove unnecessary CSS code for h1#wb-cont

### DIFF
--- a/en/css/blog.css
+++ b/en/css/blog.css
@@ -54,14 +54,6 @@ h1 {
 	border-bottom: none;
 }
 
-h1#wb-cont::after {
-	content: ""; /* This is necessary for the pseudo element to work. */
-	display: block; /* This will put the pseudo element on its own line. */
-	width: 70px; /* Change this to whatever width you want to have before hover. */
-	padding-bottom: 8px; /* This creates some space between the element and the border. */
-	border-bottom: 0.18em solid #af3c43; /* This creates the border. Replace black with whatever color you want. */
-}
-
 h1 span.stacked {
 	display: flex;
 	flex-direction: column-reverse;


### PR DESCRIPTION
---
name: Hotfix
about: This a pull request to remove unnecessary CSS code
title: 'Remove unnecessary CSS code for h1#wb-cont'
labels: 'bug'
assignees: 'delisma'
---

### What does this MR do?
Following the implementation of the h1.gc-thickline style as the default for h1#wb-cont in GCWeb, we are proceeding to remove the custom CSS.