### PR TITLE
Fix: Update default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,15 +11,15 @@ layout: core
 		Page untitled
 	{%- endif -%}
 {%- endcapture -%}
-	<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="{% if page.layout == "post" %}Blog{% else %}WebPageElement{%  endif %}">
-		{%- if page.section-title or site.title -%}
-		<h1 property="name" id="wb-cont" property="name headline" dir="ltr">
+	<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="{% if page.layout == 'post' %}Blog{% else %}WebPageElement{% endif %}">
+		{%- if page.section-title or site.title and page.title != site.title[ page.language ] -%}
+		<h1 property="name" id="wb-cont" dir="ltr">
 			<span class="stacked">
 				<span>{{ page-title }}</span>: <span>{%- if page.section-title -%}{{ page.section-title }}{%- else -%}{{ site.title[ page.language ] }}{%- endif -%}</span>
 			</span>
 		</h1>
 		{%- else -%}
-		<h1 class="gc-thickline" id="wb-cont">{{ page-title }}</h1>
+		<h1 property="name" id="wb-cont" dir="ltr">{{ page-title }}</h1>
 		{%- endif -%}
 		{{ content }}
 		{% include page-details/footer.html %}


### PR DESCRIPTION
---
name: General
about: This a pull request to fix the double title on home pages
title: 'Update default.html'
labels: 'bug'
assignees: '@delisma'
---


### What does this MR do?

This merge request updates the default.html template to ensure that when a page title matches the site title, the h1 element does not use the stacked format. This change improves clarity and prevents redundancy in the page headers.

### General checklist

- [ ] [Documentation](README.md) created/updated
- [x] Changelog entry added, if necessary
- [ ] Tests added for this feature/bug
- [x] Conforms to the [style guides](https://www.canada.ca/en/government/about/design-system.html)

### Related issues
No issue ticket created