### PR TITLE
Hotfix/adobe analytics metatags 2

### DIFF
--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -28,6 +28,8 @@
 	{%- endif %}
 <meta name="author" content="{{ site.author[ page.language ] }}" />
 {%- endif %}
+<meta name="dcterms.accessRights” content="2"/>
+<meta name= "gcaaterms.sitename" content="ESDC-EDSC_Canada-Blog"/>
 <meta name="dcterms.language" title="ISO639-2/T" content="{{ site.language[ page.language ] | downcase | truncate: 3, '' }}"/>
 {%- if page.subject %}
 <meta name="dcterms.subject" title="gccore" content="{{ page.subject }}"/>

--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -28,8 +28,8 @@
 	{%- endif %}
 <meta name="author" content="{{ site.author[ page.language ] }}" />
 {%- endif %}
-<meta name="dcterms.accessRights” content="2"/>
-<meta name= "gcaaterms.sitename" content="ESDC-EDSC_Canada-Blog"/>
+<meta name="dcterms.accessRights" content="2"/>
+<meta name="gcaaterms.sitename" content="ESDC-EDSC_Canada-Blog"/>
 <meta name="dcterms.language" title="ISO639-2/T" content="{{ site.language[ page.language ] | downcase | truncate: 3, '' }}"/>
 {%- if page.subject %}
 <meta name="dcterms.subject" title="gccore" content="{{ page.subject }}"/>


### PR DESCRIPTION
Add: dcterms.accessRights, gcaaterms.sitename meta tags for Adobe Analytics