### PR TITLE
fix: update sitemap frequency and priority defaults

### DIFF
--- a/_data/locales/sitemap.yml
+++ b/_data/locales/sitemap.yml
@@ -1,9 +1,0 @@
-daily:
-  en: daily
-  fr: quotidien
-weekly:
-  en: weekly
-  fr: hebdomadaire
-monthly:
-  en: monthly
-  fr: mensuel

--- a/en/sitemap.xml
+++ b/en/sitemap.xml
@@ -5,30 +5,33 @@ sitemap:
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{%- assign locales = site.data.locales.sitemap  -%}
   {%- for post in site.posts -%}
     {%- if post.language== page.language -%}
-    <url>
-      <loc>{{ post.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
+  <url>
+    <loc>{{ post.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
       {%- if post.dateModified == null -%}
-        <dateModified>{{ post.date | date: "%F" }}</dateModified>
+    <lastmod>{{ post.date | date: "%F" }}</lastmod>
       {% else %}
-        <dateModified>{{ post.dateModified | date: "%F" }}</dateModified>
+    <lastmod>{{ post.dateModified | date: "%F" }}</lastmod>
       {%- endif -%}
-      <changefreq>{{ locales.weekly[ post.language] }}</changefreq>
-      <priority>1.0</priority>
-    </url>
+    <changefreq>{{ post.sitemap.changefreq | default: 'weekly' }}</changefreq>
+    <priority>{{ post.sitemap.priority | default: 1.0 }}</priority>
+  </url>
     {%- endif -%}
   {%- endfor -%}
   {%- for single_page in site.pages -%}
     {%- if single_page.language == page.language -%}
       {%- unless single_page.sitemap.exclude -%}
-      <url>
-        <loc>{{ single_page.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
-        <dateModified>{{ single_page.dateModified | date: "%F" }}</dateModified>
-        <changefreq>{{ single_page.sitemap.changefreq }}</changefreq>
-        <priority>{{ single_page.sitemap.priority }}</priority>
-       </url>
+  <url>
+    <loc>{{ single_page.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
+        {%- if single_page.dateModified == null -%}
+    <lastmod>{{ single_page.date | date: "%F" }}</lastmod>
+        {% else %}
+    <lastmod>{{ single_page.dateModified | date: "%F" }}</lastmod>
+        {%- endif -%}
+    <changefreq>{{ single_page.sitemap.changefreq | default: 'yearly' }}</changefreq>
+    <priority>{{ single_page.sitemap.priority | default: 0.8 }}</priority>
+  </url>
       {%- endunless -%}
     {%- endif -%}
   {%- endfor -%}

--- a/fr/sitemap.xml
+++ b/fr/sitemap.xml
@@ -5,30 +5,33 @@ sitemap:
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{%- assign locales = site.data.locales.sitemap  -%}
   {%- for post in site.posts -%}
     {%- if post.language== page.language -%}
-    <url>
-      <loc>{{ post.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
+  <url>
+    <loc>{{ post.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
       {%- if post.dateModified == null -%}
-        <dateModified>{{ post.date | date: "%F" }}</dateModified>
+    <lastmod>{{ post.date | date: "%F" }}</lastmod>
       {% else %}
-        <dateModified>{{ post.dateModified | date: "%F" }}</dateModified>
-      {%- endif -%}
-      <changefreq>{{ locales.weekly[ post.language] }}</changefreq>
-      <priority>1.0</priority>
-    </url>
+    <lastmod>{{ post.dateModified | date: "%F" }}</lastmod>
+     {%- endif -%}
+    <changefreq>{{ post.sitemap.changefreq | default: 'weekly' }}</changefreq>
+    <priority>{{ post.sitemap.priority | default: 1.0 }}</priority>
+  </url>
     {%- endif -%}
   {%- endfor -%}
   {%- for single_page in site.pages -%}
     {%- if single_page.language == page.language -%}
       {%- unless single_page.sitemap.exclude -%}
-      <url>
-        <loc>{{ single_page.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
-        <dateModified>{{ single_page.dateModified | date: "%F" }}</dateModified>
-        <changefreq>{{ single_page.sitemap.changefreq }}</changefreq>
-        <priority>{{ single_page.sitemap.priority }}</priority>
-       </url>
+  <url>
+    <loc>{{ single_page.url | remove_first: '/' | remove_first: page.language | prepend: site.urlalt[ page.language ] }}</loc>
+      {%- if single_page.dateModified == null -%}
+    <lastmod>{{ single_page.date | date: "%F" }}</lastmod>
+      {% else %}
+    <lastmod>{{ single_page.dateModified | date: "%F" }}</lastmod>
+      {%- endif -%}
+    <changefreq>{{ single_page.sitemap.changefreq | default: 'yearly' }}</changefreq>
+    <priority>{{ single_page.sitemap.priority | default: 0.8 }}</priority>
+  </url>
       {%- endunless -%}
     {%- endif -%}
   {%- endfor -%}


### PR DESCRIPTION
Adjust the default values for sitemap frequency and priority in the XML files to improve SEO. Remove the outdated localization file for sitemap settings. This change ensures that the sitemap reflects more appropriate defaults for content updates.

## Preview links:

- https://deploy-preview-218--blogue-sct.netlify.app/sitemap.xml
- https://deploy-preview-218--blog-tbs.netlify.app/sitemap.xml

close #217