### PR TITLE
Fix language filter in RSS feed templates

### DIFF
--- a/en/feed.xml
+++ b/en/feed.xml
@@ -13,7 +13,7 @@ sitemap:
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
-    {%- assign posts=site.posts | where:"lang", page.language -%}
+    {%- assign posts=site.posts | where:"language", page.language -%}
     {%- for post in posts limit:10 -%}
       <item>
         <title>{{ post.title | xml_escape }}</title>

--- a/fr/flux.xml
+++ b/fr/flux.xml
@@ -11,7 +11,7 @@ layout: null
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
-    {%- assign posts=site.posts | where:"lang", page.language -%}
+    {%- assign posts=site.posts | where:"language", page.language -%}
     {%- for post in posts limit:10 -%}
       <item>
         <title>{{ post.title | xml_escape }}</title>


### PR DESCRIPTION
Correct the language filter in the RSS feed templates to ensure proper functionality. This change updates the filter from "lang" to "language" for accurate post retrieval based on the specified language.

close #215
