### PR TITLE
Update CEO email address in configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ author:
   fr: Emploi et Développement social Canada
 baseurl: ""
 emails:
-  dto: cds.dto-btn.snc@servicecanada.gc.ca
+  dto: dsd.ceo-bec.dsn@servicecanada.gc.ca
 description:
   en: Evidence and insights from the Canada.ca team.
   fr: Validations et perspectives de l'équipe Canada.ca.


### PR DESCRIPTION
Change the CEO email address in the configuration file to ensure accurate contact information. This update reflects the current email for the CEO.

