### PR TITLE
Hotfix: Add external "About Canada.ca" breadcrumb to blog home pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,9 @@ defaults:
     scope:
       path: "en/"
     values:
+      breadcrumbs:
+      - title: "About Canada.ca"
+        link:  "https://www.canada.ca/en/government/about-canada-ca.html"
       contextualFooter:
         title: Canada.ca Experience Office (CEO)
         links:
@@ -94,6 +97,9 @@ defaults:
     scope:
       path: "fr/"
     values:
+      breadcrumbs:
+      - title: "À propos de Canada.ca"
+        link:  "https://www.canada.ca/fr/gouvernement/a-propos-canada-ca.html"
       contextualFooter:
         title: Bureau de l’expérience Canada.ca (BEC)
         links:
@@ -107,7 +113,7 @@ defaults:
     values:
       breadcrumbs:
       - title: "About Canada.ca"
-        link:  "https://www.canada.ca/en/government/about.html"
+        link:  "https://www.canada.ca/en/government/about-canada-ca.html"
       - title: Canada.ca blog
         link: "https://blog.canada.ca/"
         type: "Blog"
@@ -117,8 +123,8 @@ defaults:
       type: "posts"
     values:
       breadcrumbs:
-      - title: "A propos de Canada.ca"
-        link:  "https://www.canada.ca/fr/gouvernement/a-propos.html"
+      - title: "À propos de Canada.ca"
+        link:  "https://www.canada.ca/fr/gouvernement/a-propos-canada-ca.html"
       - title: Blogue de Canada.ca
         link: "https://blogue.canada.ca/"
         type: "Blog"

--- a/_data/locales/post.yml
+++ b/_data/locales/post.yml
@@ -1,9 +1,9 @@
 abouturl:
-  en: https://www.canada.ca/en/government/about.html
-  fr: https://www.canada.ca/fr/gouvernement/a-propos.html
+  en: https://www.canada.ca/en/government/about-canada-ca.html
+  fr: https://www.canada.ca/fr/gouvernement/a-propos-canada-ca.html
 abouttitle:
   en: About Canada.ca
-  fr: A propos de Canada.ca
+  fr: À propos de Canada.ca
 connect:
   en: Connect with the Canada.ca Experience Office at ESDC
   fr: Communiquez avec le Bureau de l’expérience Canada.ca du EDSC


### PR DESCRIPTION
## Summary
- `en/index.html` and `fr/index.html` now show a single breadcrumb level linking to the corresponding About Canada.ca page, via `_config.yml` scope defaults for `en/` and `fr/`
- Matches the top-level crumb already used on individual post pages (`About Canada.ca` → `Canada.ca blog` → post)

## Test plan
- [x] Fresh local build (`bundle exec rake build`, production config) — no errors
- [x] Verified `_site/en/index.html` breadcrumb renders `About Canada.ca` → `https://www.canada.ca/en/government/about.html`
- [x] Verified `_site/fr/index.html` breadcrumb renders `A propos de Canada.ca` → `https://www.canada.ca/fr/gouvernement/a-propos.html`
- [x] Both language directories built successfully with no other regressions

<!-- preview-urls:start -->
## 🚀 PR Preview

Latest commit: [2e10305](https://github.com/canada-ca/blogue-canada-ca-blog/commit/2e10305bfef281ae9cf62b6425cae1bcc5befba5)

| Page | English | French |
| --- | --- | --- |
| Site home | [https://test.canada.ca/blog/pr-preview/pr-234/](https://test.canada.ca/blog/pr-preview/pr-234/) | [https://test.canada.ca/blogue/pr-preview/pr-234/](https://test.canada.ca/blogue/pr-preview/pr-234/) |

## 📁 Other changed files

| File |
| --- |
| [_config.yml](https://github.com/canada-ca/blogue-canada-ca-blog/blob/2e10305bfef281ae9cf62b6425cae1bcc5befba5/_config.yml) |
| [_data/locales/post.yml](https://github.com/canada-ca/blogue-canada-ca-blog/blob/2e10305bfef281ae9cf62b6425cae1bcc5befba5/_data/locales/post.yml) |

---

<sub><em>Preview updates automatically with each commit.</em></sub>
<!-- preview-urls:end -->
